### PR TITLE
Support nested objects

### DIFF
--- a/example/plopfile.js
+++ b/example/plopfile.js
@@ -26,6 +26,29 @@ module.exports = (plop) => {
           }
         },
         {
+          // Test Nested Objects
+          type: 'json-modify-file', // Strategy to use
+          force: true,
+          JSONFile: './destination.json', // The file to modify
+          JSONKey: 'nestedObj', // Where in the json file we add ourselves? - Can do root?
+          JSONEntryKey: '{{pascalCase name}}', // if missing use array
+          JSONEntryValue: {
+            child1a: {
+              child2a: {
+                '{{camelCase name}}': '{{name}} {{camelCase name}} {{snakeCase name}}',
+                test: 'test'
+              },
+              child2b: {
+                test: 'test'
+              }
+            },
+            child1b: {
+              '{{camelCase name}}': '{{dashCase name}} {{dotCase name}} {{pathCase name}}',
+              test: 'test'
+            }
+          },
+        },
+        {
           // Arrays
           type: 'json-modify-file', // Strategy to use
           force: true,

--- a/index.js
+++ b/index.js
@@ -97,7 +97,8 @@ module.exports = function (plop, cfg) {
             throw "Attribute: " + property_name + ' already exist in ' + config.JSONKey
         }
         // Process the Value - change this for handlebars
-        let insert_val = replace(config.JSONEntryValue, vars, plop);
+        let stringified_insert_val = replace(json3.stringify(config.JSONEntryValue), vars, plop);
+        let insert_val = json3.parse(stringified_insert_val);
         debug(`Adding: `, insert_val);
 
         // Choosing object (key:value) OR push(value)


### PR DESCRIPTION
```js
export default function (plop) {
  plop.load('plop-pack-json-modify');
  plop.setGenerator('Sample', {
    description: 'test',
    prompts: [
      {
        type: 'input',
        name: 'id',
        message: 'input id',
      },
    ],
    actions: [
      {
        type: 'json-modify-file',
        force: true,
        JSONFile: 'nested.json',
        JSONKey: 'parent',
        JSONEntryValue: {
          child1: {
            child2: {
              '{{id}}': '{{id}}',
            }
          }
        },
      },
    ],
  });
}

```

```
✖  json-modify-file You must pass a string or Handlebars AST to Handlebars.compile. You passed [object Object]
```

I have fixed the error when nested object is passed `JSONEntryValue`.